### PR TITLE
Add `kick yes` and `kick no` options to fix nvt/sllod/chunk for applying

### DIFF
--- a/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
+++ b/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
@@ -50,6 +50,7 @@ ComputeTempDeformChunk::ComputeTempDeformChunk(LAMMPS *lmp, int narg, char **arg
   extvector = 1;
   tempflag = 1;
   tempbias = 1;
+  maxbias = 0;
   vbiasall = nullptr;
   vthermal = nullptr;
 

--- a/src/MOL-SLLOD/fix_nvt_sllod_chunk.h
+++ b/src/MOL-SLLOD/fix_nvt_sllod_chunk.h
@@ -30,10 +30,12 @@ class FixNVTSllodChunk : public FixNH {
   ~FixNVTSllodChunk();
 
   void init() override;
+  void setup(int) override;
 
  private:
   int nondeformbias;
   int nchunk, maxchunk;
+  int kickflag;           // Whether to apply the streaming profile on init
   double **vcm, **vcmall;
   double *massproc, *masstotal;
 

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -363,6 +363,10 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) :
       idchunk = utils::strdup(arg[iarg+1]);
       idvcm = utils::strdup(arg[iarg+2]);
       iarg += 3;
+
+    // keyword kick parsed in fix nvt/sllod
+    } else if (strcmp(arg[iarg], "kick") == 0) {
+      iarg += 2;
     } else error->all(FLERR,"Illegal fix nvt/npt/nph command");
   }
 

--- a/src/fix_nh.cpp
+++ b/src/fix_nh.cpp
@@ -364,7 +364,7 @@ FixNH::FixNH(LAMMPS *lmp, int narg, char **arg) :
       idvcm = utils::strdup(arg[iarg+2]);
       iarg += 3;
 
-    // keyword kick parsed in fix nvt/sllod
+    // keyword kick parsed in fix nvt/sllod/chunk
     } else if (strcmp(arg[iarg], "kick") == 0) {
       iarg += 2;
     } else error->all(FLERR,"Illegal fix nvt/npt/nph command");

--- a/src/fix_nh.h
+++ b/src/fix_nh.h
@@ -24,7 +24,7 @@ class FixNH : public Fix {
   ~FixNH() override;
   int setmask() override;
   void init() override;
-  void setup(int) override;
+  virtual void setup(int) override;
   void initial_integrate(int) override;
   void final_integrate() override;
   void initial_integrate_respa(int, int, int) override;


### PR DESCRIPTION
**Summary**

Adds `kick yes` and `kick no` options to `fix nvt/sllod/chunk` to apply velocity bias on startup.

Also fixes segfault in compute temp/deform/chunk caused by missing default for `maxbias`.

**Implementation Notes**

Works by removing bias, then restoring twice on first call to setup(). Should be transferable to `fix nvt/sllod` as well down the track.

