### PR TITLE
Cache invalidation fixes

### DIFF
--- a/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
+++ b/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
@@ -530,8 +530,6 @@ void ComputeTempDeformChunk::remove_bias(int i, double *v)
   int index = cchunk->ichunk[i]-1;
   if (index < 0) return;
 
-  com_compute();
-
   domain->x2lamda(comall[index], lamda);
   vstream_chunk[0] = h_rate[0] * lamda[0] + h_rate[5] * lamda[1] + h_rate[4] * lamda[2] + h_ratelo[0];
   vstream_chunk[1] = h_rate[1] * lamda[1] + h_rate[3] * lamda[2] + h_ratelo[1];
@@ -579,8 +577,6 @@ void ComputeTempDeformChunk::remove_bias_all()
   double **v = atom->v;
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
-
-  com_compute();
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {

--- a/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
+++ b/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
@@ -530,9 +530,7 @@ void ComputeTempDeformChunk::remove_bias(int i, double *v)
   int index = cchunk->ichunk[i]-1;
   if (index < 0) return;
 
-  if(comstep != update->ntimestep) {
-    com_compute();
-  }
+  com_compute();
 
   domain->x2lamda(comall[index], lamda);
   vstream_chunk[0] = h_rate[0] * lamda[0] + h_rate[5] * lamda[1] + h_rate[4] * lamda[2] + h_ratelo[0];
@@ -582,9 +580,7 @@ void ComputeTempDeformChunk::remove_bias_all()
   int *mask = atom->mask;
   int nlocal = atom->nlocal;
 
-  if(comstep != update->ntimestep) {
-    com_compute();
-  }
+  com_compute();
 
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {

--- a/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
+++ b/src/MOL-SLLOD/compute_temp_deform_chunk.cpp
@@ -166,6 +166,7 @@ void ComputeTempDeformChunk::init()
 double ComputeTempDeformChunk::compute_scalar()
 {
   int i;
+  invoked_scalar = update->ntimestep;
 
   // calculate chunk assignments,
   //   since only atoms in chunks contribute to global temperature
@@ -264,6 +265,8 @@ double ComputeTempDeformChunk::compute_scalar()
 void ComputeTempDeformChunk::compute_vector()
 {
   int i;
+
+  invoked_vector = update->ntimestep;
 
   // calculate chunk assignments,
   //   since only atoms in chunks contribute to global temperature

--- a/src/MOL-SLLOD/fix_nvt_sllod_chunk.cpp
+++ b/src/MOL-SLLOD/fix_nvt_sllod_chunk.cpp
@@ -82,7 +82,7 @@ void FixNVTSllodChunk::init() {
     error->all(FLERR,"Temperature for fix nvt/sllod/chunk does not have a bias");
 
   nondeformbias = 0;
-  if (strcmp(temperature->style,"temp/deform") != 0) nondeformbias = 1;
+  if (strcmp(temperature->style,"temp/deform/chunk") != 0) nondeformbias = 1;
 
   // check fix deform remap settings
 

--- a/src/MOL-SLLOD/fix_nvt_sllod_chunk.cpp
+++ b/src/MOL-SLLOD/fix_nvt_sllod_chunk.cpp
@@ -142,6 +142,7 @@ void FixNVTSllodChunk::setup(int vflag) {
   // Apply kick if necessary
   if (kickflag) {
     // Call remove_bias first to calculate biases
+    temperature->compute_scalar();
     temperature->remove_bias_all();
 
     // Restore twice to apply streaming profile


### PR DESCRIPTION
**Summary**

This patch removes COM and VCM caching in ComputeTempDeformChunk. The old scheme assumed that the molecular centre-of-mass positions were good to re-use for the whole timestep, but that's not true as the temperature compute will be used inside the integrator, so the COM positions and velocities will change in between invocations of ComputeTempDeformChunk::compute_scalar().

I fixed two instances where the computes were getting called unnecessarily:

1. FixNVTSllodChunk didn't correctly recognise that ComputeTempDeformChunk has a compatible bias, so it was unnecessarily calling compute_scalar() at the start of nh_v_temp(). This does not change the output at all.
 2. I re-ordered the calls to remove_bias() in nh_v_temp(), since ComputeTempDeformChunk::remove_bias() calls the COM compute every time it is invoked. This is unnecessary, and can be bypassed by calling remove_bias_all() once at the start of nh_v_temp() (thus working in thermal velocities for the whole thing, which is what we were doing anyway) and then calling restore_bias_all() at the end of nh_v_temp().

The cumulative effects of removing the caching changes the output of LAMMPS very slightly, although the qualitative behaviour is unchanged. It should be "correct" this way, although I would appreciate a second pair of eyes to make sure I haven't inadvertently broken anything in the process.

With these changes, the execution speed goes from 480.571 timesteps/s to 515.345 timesteps/s.
